### PR TITLE
Stylelint修正 #2

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,14 @@
 {
-  "extends": ["stylelint-config-standard-scss", "stylelint-config-property-sort-order-smacss", "stylelint-config-prettier"],
-  "rules": {},
-  "ignoreFiles": ["dist/**/**/*.css", "**/*.js"]
+  "extends": ["stylelint-config-standard-scss", "stylelint-config-property-sort-order-smacss", "stylelint-config-prettier-scss"],
+  "rules": {
+    "selector-id-pattern": null,
+    "selector-class-pattern": null,
+    "keyframes-name-pattern": null,
+    "scss/at-mixin-pattern": null,
+    "scss/dollar-variable-pattern": null,
+    "scss/percent-placeholder-pattern": null,
+    "scss/at-extend-no-missing-placeholder": null,
+    "value-keyword-case": null
+  },
+  "ignoreFiles": ["**/_reset.scss", "/dist", "**/*.js"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
   "css.validate": false,
   "less.validate": false,
   "scss.validate": false,
-  "stylelint.validate": ["css", "postcss"],
+  "stylelint.validate": ["css", "scss"],
   "markuplint.enable": true,
   "markuplint.debug": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
         "prettier": "2.7.1",
         "sass": "^1.55.0",
         "stylelint": "^14.12.1",
-        "stylelint-config-prettier": "^9.0.3",
+        "stylelint-config-prettier-scss": "^0.0.1",
         "stylelint-config-property-sort-order-smacss": "^9.0.0",
-        "stylelint-config-standard": "^28.0.0"
+        "stylelint-config-standard-scss": "^5.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4653,6 +4653,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6623,6 +6629,28 @@
         "postcss": "^8.3.3"
       }
     },
+    "node_modules/postcss-scss": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
+      "integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
@@ -7808,6 +7836,25 @@
         "stylelint": ">=11.0.0"
       }
     },
+    "node_modules/stylelint-config-prettier-scss": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier-scss/-/stylelint-config-prettier-scss-0.0.1.tgz",
+      "integrity": "sha512-lBAYG9xYOh2LeWEPC/64xeUxwOTnQ8nDyBijQoWoJb10/bMGrUwnokpt8jegGck2Vbtxh6XGwH63z5qBcVHreQ==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-prettier": ">=9.0.3"
+      },
+      "bin": {
+        "stylelint-config-prettier-scss": "bin/check.js",
+        "stylelint-config-prettier-scss-check": "bin/check.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "stylelint": ">=11.0.0"
+      }
+    },
     "node_modules/stylelint-config-property-sort-order-smacss": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-9.0.0.tgz",
@@ -7821,25 +7868,61 @@
         "stylelint": "^14.0.0"
       }
     },
-    "node_modules/stylelint-config-recommended": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-      "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-      "dev": true,
-      "peerDependencies": {
-        "stylelint": "^14.10.0"
-      }
-    },
-    "node_modules/stylelint-config-standard": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-28.0.0.tgz",
-      "integrity": "sha512-q/StuowDdDmFCravzGHAwgS9pjX0bdOQUEBBDIkIWsQuYGgYz/xsO8CM6eepmIQ1fc5bKdDVimlJZ6MoOUcJ5Q==",
+    "node_modules/stylelint-config-recommended-scss": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-7.0.0.tgz",
+      "integrity": "sha512-rGz1J4rMAyJkvoJW4hZasuQBB7y9KIrShb20l9DVEKKZSEi1HAy0vuNlR8HyCKy/jveb/BdaQFcoiYnmx4HoiA==",
       "dev": true,
       "dependencies": {
-        "stylelint-config-recommended": "^9.0.0"
+        "postcss-scss": "^4.0.2",
+        "stylelint-config-recommended": "^8.0.0",
+        "stylelint-scss": "^4.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.11.0"
+        "stylelint": "^14.4.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended-scss/node_modules/stylelint-config-recommended": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+      "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^14.8.0"
+      }
+    },
+    "node_modules/stylelint-config-standard-scss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-5.0.0.tgz",
+      "integrity": "sha512-zoXLibojHZYPFjtkc4STZtAJ2yGTq3Bb4MYO0oiyO6f/vNxDKRcSDZYoqN260Gv2eD5niQIr1/kr5SXlFj9kcQ==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended-scss": "^7.0.0",
+        "stylelint-config-standard": "^26.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.9.0"
+      }
+    },
+    "node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-recommended": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+      "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^14.8.0"
+      }
+    },
+    "node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-standard": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz",
+      "integrity": "sha512-hUuB7LaaqM8abvkOO84wh5oYSkpXgTzHu2Zza6e7mY+aOmpNTjoFBRxSLlzY0uAOMWEFx0OMKzr+reG1BUtcqQ==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended": "^8.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.9.0"
       }
     },
     "node_modules/stylelint-order": {
@@ -7853,6 +7936,22 @@
       },
       "peerDependencies": {
         "stylelint": "^14.0.0"
+      }
+    },
+    "node_modules/stylelint-scss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.3.0.tgz",
+      "integrity": "sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.6",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.5.1"
       }
     },
     "node_modules/stylelint/node_modules/ansi-regex": {
@@ -12552,6 +12651,12 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13854,6 +13959,13 @@
       "dev": true,
       "requires": {}
     },
+    "postcss-scss": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
+      "integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
+      "dev": true,
+      "requires": {}
+    },
     "postcss-selector-parser": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
@@ -14782,6 +14894,15 @@
       "dev": true,
       "requires": {}
     },
+    "stylelint-config-prettier-scss": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier-scss/-/stylelint-config-prettier-scss-0.0.1.tgz",
+      "integrity": "sha512-lBAYG9xYOh2LeWEPC/64xeUxwOTnQ8nDyBijQoWoJb10/bMGrUwnokpt8jegGck2Vbtxh6XGwH63z5qBcVHreQ==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-prettier": ">=9.0.3"
+      }
+    },
     "stylelint-config-property-sort-order-smacss": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-9.0.0.tgz",
@@ -14792,20 +14913,52 @@
         "stylelint-order": "^5.0.0"
       }
     },
-    "stylelint-config-recommended": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-      "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "stylelint-config-standard": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-28.0.0.tgz",
-      "integrity": "sha512-q/StuowDdDmFCravzGHAwgS9pjX0bdOQUEBBDIkIWsQuYGgYz/xsO8CM6eepmIQ1fc5bKdDVimlJZ6MoOUcJ5Q==",
+    "stylelint-config-recommended-scss": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-7.0.0.tgz",
+      "integrity": "sha512-rGz1J4rMAyJkvoJW4hZasuQBB7y9KIrShb20l9DVEKKZSEi1HAy0vuNlR8HyCKy/jveb/BdaQFcoiYnmx4HoiA==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended": "^9.0.0"
+        "postcss-scss": "^4.0.2",
+        "stylelint-config-recommended": "^8.0.0",
+        "stylelint-scss": "^4.0.0"
+      },
+      "dependencies": {
+        "stylelint-config-recommended": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+          "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "stylelint-config-standard-scss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-5.0.0.tgz",
+      "integrity": "sha512-zoXLibojHZYPFjtkc4STZtAJ2yGTq3Bb4MYO0oiyO6f/vNxDKRcSDZYoqN260Gv2eD5niQIr1/kr5SXlFj9kcQ==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended-scss": "^7.0.0",
+        "stylelint-config-standard": "^26.0.0"
+      },
+      "dependencies": {
+        "stylelint-config-recommended": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+          "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "stylelint-config-standard": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz",
+          "integrity": "sha512-hUuB7LaaqM8abvkOO84wh5oYSkpXgTzHu2Zza6e7mY+aOmpNTjoFBRxSLlzY0uAOMWEFx0OMKzr+reG1BUtcqQ==",
+          "dev": true,
+          "requires": {
+            "stylelint-config-recommended": "^8.0.0"
+          }
+        }
       }
     },
     "stylelint-order": {
@@ -14816,6 +14969,19 @@
       "requires": {
         "postcss": "^8.3.11",
         "postcss-sorting": "^7.0.1"
+      }
+    },
+    "stylelint-scss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.3.0.tgz",
+      "integrity": "sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.6",
+        "postcss-value-parser": "^4.1.0"
       }
     },
     "suf-log": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "prettier": "2.7.1",
     "sass": "^1.55.0",
     "stylelint": "^14.12.1",
-    "stylelint-config-prettier": "^9.0.3",
+    "stylelint-config-prettier-scss": "^0.0.1",
     "stylelint-config-property-sort-order-smacss": "^9.0.0",
-    "stylelint-config-standard": "^28.0.0"
+    "stylelint-config-standard-scss": "^5.0.0"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
- パッケージがSass対応のものになってなかったので変更
- VSCodeプラグインのフォーマット監視対象にSassファイルが入っていなかったので修正
- Stylelintの設定ファイルを変更パッケージに合わせて修正、ルールを追加

やっぱりPostCSSはViteにデフォで導入されているからインストール不要:raised_hands: